### PR TITLE
Ensure batch object has batchable methods

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -31,7 +31,10 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 $schedule->call(function () {
                     $batchedModelsClasses = static::getBatchedModelsClasses();
                     foreach ($batchedModelsClasses as $batchClass) {
-                        (new $batchClass)->checkBatchingStatusAndDispatchIfNecessary($batchClass);
+                        $instantiatedBatchObject = new $batchClass;
+                        if(method_exists($instantiatedBatchObject, 'checkBatchingStatusAndDispatchIfNecessary')) {
+                            $instantiatedBatchObject->checkBatchingStatusAndDispatchIfNecessary($batchClass);
+                        }
                     }
                 })->description('Scout Batch Searchable')->everyMinute();
             });


### PR DESCRIPTION
I am encountering a bug in production where there is a class in the BATCH_SEARCHABLE_QUEUED_MODELS cache that does not use the BatchSearchable, leading to an expection being thrown every minute by the scheduler.

This PR patches the bug but doesn't resolve the underlying problem with the incorrect class being added to the Cache. 

It looks like this happens because this package overrides the searchable method on the base Collection, so if that is called and the collection contains objects that do not have the BatchSearchable trait, it will still add those classes to the BATCH_SEARCHABLE_QUEUED_MODELS cache.

Edit: I was incorrect about the scheduler not processing the rest of the commands.
