### PR TITLE
Fix absolute param issue in diffByMinutes caused by difference in Carbon versions

### DIFF
--- a/src/BatchSearchable.php
+++ b/src/BatchSearchable.php
@@ -132,7 +132,7 @@ trait BatchSearchable
         $maxBatchSizeExceeded = sizeof($cachedValue['models']) >= $maxBatchSize;
 
         $maxTimeInMin = Config::get('scout.batch_searchable_debounce_time_in_min', 1);
-        $maxTimePassed = Carbon::now()->diffInMinutes($cachedValue['updated_at']) >= $maxTimeInMin;
+        $maxTimePassed = Carbon::now()->diffInMinutes($cachedValue['updated_at'], $absolute = true) >= $maxTimeInMin;
 
         if ($maxBatchSizeExceeded || $maxTimePassed) {
             ServiceProvider::removeBatchedModelClass($className);


### PR DESCRIPTION
Carbon v3 has a changed `diffInMinutes` method signature. 

It changed a default value of `$absolute` param from `true` to `false`. This is causing `maxTimePassed` never to be true as the comparison checks if it is greater (or equal) to `$maxTimeInMin`.

Set `$absolute` param in `diffInMinutes` explicitly to `true`.

Fixes #10.